### PR TITLE
Fix console log wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,7 +497,7 @@
             const docRef = hustleTasksCollection.doc(dateString);
 
             try {
-                console.log(`Workspaceing document: ${docRef.path}`);
+                console.log(`Fetching document: ${docRef.path}`);
                 const docSnap = await docRef.get(); // Attempt to get the document
 
                 if (docSnap.exists) { // Check the boolean property for Compat SDK


### PR DESCRIPTION
## Summary
- change `Workspaceing document` log to `Fetching document`

## Testing
- `grep -n "Fetching document" -n index.html`