### PR TITLE
Fix service worker path handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2262,8 +2262,8 @@
     <script>
         // Register service worker for PWA functionality
         if ('serviceWorker' in navigator) {
-            const isGitHubPages = window.location.hostname.includes('github.io');
-            const swPath = isGitHubPages ? '/sng-hustle-board/service-worker.js' : '/service-worker.js';
+            // Determine the correct service worker path relative to the current page
+            const swPath = new URL('service-worker.js', window.location.href).pathname;
             window.addEventListener('load', () => {
                 navigator.serviceWorker.register(swPath)
                     .then(reg => console.log('Service Worker registered:', reg.scope))

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,8 +1,8 @@
 // service-worker.js
 
-// Adjust paths for GitHub Pages if needed
-const isGitHubPages = self.location.hostname.includes('github.io');
-const basePath = isGitHubPages ? '/sng-hustle-board/' : '/';
+// Determine the base path dynamically from the service worker location
+// This supports repositories with unusual names (e.g. with trailing dots)
+const basePath = self.location.pathname.replace(/service-worker\.js$/, '');
 
 const CACHE_NAME = 'sng-hustle-board-v1';
 const ASSETS_TO_CACHE = [
@@ -180,8 +180,8 @@ self.addEventListener('push', (event) => {
 
     const options = {
       body: data.body || 'Task update',
-      icon: isGitHubPages ? '/sng-hustle-board/icon-192.png' : '/icon-192.png', // Updated icon path
-      badge: isGitHubPages ? '/sng-hustle-board/icon-192.png' : '/icon-192.png', // Updated badge path
+      icon: basePath + 'icon-192.png',
+      badge: basePath + 'icon-192.png',
       tag: `task-${data.taskId}`, // Use tag to replace existing notification
       data: {
         taskId: data.taskId,
@@ -224,8 +224,8 @@ self.addEventListener('message', (event) => {
     // Options for showing/updating the notification
     const options = {
       body: `${taskData.text}\n${taskData.progressInfo || ''}`,
-      icon: isGitHubPages ? '/sng-hustle-board/icon-192.png' : '/icon-192.png', // Updated icon path
-      badge: isGitHubPages ? '/sng-hustle-board/icon-192.png' : '/icon-192.png', // Updated badge path
+      icon: basePath + 'icon-192.png',
+      badge: basePath + 'icon-192.png',
       tag: `task-${taskData.id}`, // Use tag to replace existing notification
       renotify: true, // Important to alert user of update (on supported platforms)
       data: { // Include data for notificationclick handler


### PR DESCRIPTION
## Summary
- fix dynamic basePath calculation inside service worker
- register service worker using a path relative to the current page

## Testing
- `git log -1 --stat`
